### PR TITLE
clang-tidy: Fix esri-no-implementation-in-headers check

### DIFF
--- a/clang-tools-extra/clang-tidy/esri/NoImplementationInHeadersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/esri/NoImplementationInHeadersCheck.cpp
@@ -179,6 +179,11 @@ void NoImplementationInHeadersCheck::check(
       const auto *DC = MD->getDeclContext();
       while (DC->isRecord()) {
         if (const auto *RD = dyn_cast<CXXRecordDecl>(DC)) {
+          // If the definition is a lambda type then ignore.
+          if (RD->isLambda()) {
+            return;    
+          }
+
           if (isa<ClassTemplatePartialSpecializationDecl>(RD)) {
             return;
           }
@@ -237,6 +242,9 @@ void NoImplementationInHeadersCheck::check(
     if (VD->getDeclContext()->isDependentContext() && VD->isStaticDataMember())
       return;
     if (isTemplateInstantiation(VD->getTemplateSpecializationKind()))
+      return;
+    // Ignore if the variable is constexpr.
+    if (VD->isConstexpr())
       return;
     // Ignore variable definition within function scope.
     if (VD->hasLocalStorage() || VD->isStaticLocal())

--- a/clang-tools-extra/test/clang-tidy/esri-no-implementation-in-headers.hpp
+++ b/clang-tools-extra/test/clang-tidy/esri-no-implementation-in-headers.hpp
@@ -191,3 +191,26 @@ class StaticConstExpr {
     return 2;
   }
 };
+
+constexpr int foo = 42; // OK: constexpr variable defined in header.
+
+template<typename T>
+struct EB {
+  static constexpr bool value = true;
+};
+
+template<typename T>
+constexpr bool is_good = EB<T>::value; // OK: constexpr variable defined in template.
+
+template<typename Fn>
+int DoubleValue(int n, Fn&& fn)
+{
+  return fn(n);
+}
+
+template<int N>
+int callDoubleValue()
+{
+  // OK: lambda is an implicitly inline operator() with definition, allowed in headers.
+  return DoubleValue(N, [](const int v){ return v*2;}); 
+}

--- a/clang-tools-extra/test/clang-tidy/esri-no-implementation-in-headers.hpp
+++ b/clang-tools-extra/test/clang-tidy/esri-no-implementation-in-headers.hpp
@@ -142,6 +142,11 @@ namespace {
 int e = 2; // CHECK-MESSAGES: :[[@LINE]]:5: warning: anonymously namespaced 'e' defined in a header file;
 } // namespace
 
+// Even if a definition is constexpr, anonymous namespaces are not allowed.
+namespace {
+constexpr int invalid_constexpr_var = 2; // CHECK-MESSAGES: :[[@LINE]]:15: warning: anonymously namespaced 'invalid_constexpr_var' defined in a header file; 
+} // namespace
+
 const char *const g = "foo"; // OK: internal linkage variable definition.
 static int h = 1;            // OK: internal linkage variable definition.
 const int i = 1;             // OK: internal linkage variable definition.
@@ -194,13 +199,14 @@ class StaticConstExpr {
 
 constexpr int foo = 42; // OK: constexpr variable defined in header.
 
+// Helper struct for defining a constexpr variable in a template.
 template<typename T>
-struct EB {
+struct AllowedVariable {
   static constexpr bool value = true;
 };
 
 template<typename T>
-constexpr bool is_good = EB<T>::value; // OK: constexpr variable defined in template.
+constexpr bool allowed_variable_value = AllowedVariable<T>::value; // OK: constexpr variable defined in template.
 
 template<typename Fn>
 int DoubleValue(int n, Fn&& fn)


### PR DESCRIPTION
This PR fixes the `esri-no-implementation-in-headers` check for the following cases-

1. If the variable defined in a header is `constexpr` then ignore.
2. If a function definition is a lambda then ignore. Since lambda's are implicitly inlined
`operator()` with a definition, the checker would catch that, but ignore this for lambda's.

The PR also adds tests to verify for these cases such that the checker is ok with
this kind of code in headers.