### PR TITLE
docs: Add instructions for building arm64 linux support

### DIFF
--- a/llvm.dockerfile
+++ b/llvm.dockerfile
@@ -1,5 +1,5 @@
 # Container that has all the tools needed to build the llvm-project and all additional tools
-FROM harbor-west.esri.com/runtime-docker-public/ubuntu:20.04
+FROM ubuntu:20.04
 
 # This stops krb5-user package from prompting for geographic region
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Issue-number: https://devtopia.esri.com/runtime/devops/issues/1944

Updates RTC's readme with instructions on how to build llvm as a cross-compiler and also building it for arm64
