### PR TITLE
clang-tidy: add esri-implicit-cast-to-sizet checker

### DIFF
--- a/clang-tools-extra/clang-tidy/esri/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/esri/CMakeLists.txt
@@ -2,6 +2,7 @@ set(LLVM_LINK_COMPONENTS support)
 
 add_clang_library(clangTidyEsriModule
   EsriTidyModule.cpp
+  ImplicitCastToSizetCheck.cpp
   NoImplementationInHeadersCheck.cpp
 
   LINK_LIBS

--- a/clang-tools-extra/clang-tidy/esri/EsriTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/esri/EsriTidyModule.cpp
@@ -12,6 +12,7 @@
 #include "../ClangTidy.h"
 #include "../ClangTidyModule.h"
 #include "../ClangTidyModuleRegistry.h"
+#include "ImplicitCastToSizetCheck.h"
 #include "NoImplementationInHeadersCheck.h"
 
 namespace clang {
@@ -21,6 +22,8 @@ namespace esri {
 class EsriModule : public ClangTidyModule {
 public:
   void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
+    CheckFactories.registerCheck<ImplicitCastToSizetCheck>(
+        "esri-implicit-cast-to-sizet");
     CheckFactories.registerCheck<NoImplementationInHeadersCheck>(
         "esri-no-implementation-in-headers");
   }

--- a/clang-tools-extra/clang-tidy/esri/ImplicitCastToSizetCheck.cpp
+++ b/clang-tools-extra/clang-tidy/esri/ImplicitCastToSizetCheck.cpp
@@ -70,20 +70,19 @@ void ImplicitCastToSizetCheck::check(const MatchFinder::MatchResult &Result) {
     // not a negative value
     if (ExprResultWidth == 32 && !ConstExprResult->isNegative())
       return;
-    else {
-      // Make sure the constant value was within the valid range for a 32-bit
-      // unsigned integer (size_t on windows_x86)
-      auto MaxValue = llvm::APSInt::getMaxValue(32, true);
-      MaxValue = MaxValue.extOrTrunc(ExprResultWidth);
-      MaxValue.setIsSigned(ConstExprResult->isSigned());
 
-      auto MinValue = llvm::APSInt::getMinValue(32, true);
-      MinValue = MinValue.extOrTrunc(ExprResultWidth);
-      MinValue.setIsSigned(ConstExprResult->isSigned());
+    // Make sure the constant value was within the valid range for a 32-bit
+    // unsigned integer (size_t on windows_x86)
+    auto MaxValue = llvm::APSInt::getMaxValue(32, true);
+    MaxValue = MaxValue.extOrTrunc(ExprResultWidth);
+    MaxValue.setIsSigned(ConstExprResult->isSigned());
 
-      if (*ConstExprResult < MaxValue && *ConstExprResult >= MinValue)
-        return;
-    }
+    auto MinValue = llvm::APSInt::getMinValue(32, true);
+    MinValue = MinValue.extOrTrunc(ExprResultWidth);
+    MinValue.setIsSigned(ConstExprResult->isSigned());
+
+    if (*ConstExprResult < MaxValue && *ConstExprResult >= MinValue)
+      return;
   }
 
   diag(MatchedExpr->getBeginLoc(), "implicit cast to size_t may be a narrowing cast")

--- a/clang-tools-extra/clang-tidy/esri/ImplicitCastToSizetCheck.cpp
+++ b/clang-tools-extra/clang-tidy/esri/ImplicitCastToSizetCheck.cpp
@@ -39,6 +39,12 @@ void ImplicitCastToSizetCheck::registerMatchers(MatchFinder *Finder) {
         unless(ConditionalWithLiterals),  // ...or a ternary operator where both branches are literals
         unless(parenExpr(                 // ...or parenthesis surrounding a
           has(ConditionalWithLiterals)    // ...ternary operator where both branches are literals
+        )),
+
+        unless(binaryOperator(            // ...or a subtraction of two pointers
+          hasOperatorName("-"),
+          hasLHS(hasType(isAnyPointer())),
+          hasRHS(hasType(isAnyPointer()))
         ))
       ).bind("se"))
     ).bind("implicit_cast"),

--- a/clang-tools-extra/clang-tidy/esri/ImplicitCastToSizetCheck.cpp
+++ b/clang-tools-extra/clang-tidy/esri/ImplicitCastToSizetCheck.cpp
@@ -81,7 +81,7 @@ void ImplicitCastToSizetCheck::check(const MatchFinder::MatchResult &Result) {
     MinValue = MinValue.extOrTrunc(ExprResultWidth);
     MinValue.setIsSigned(ConstExprResult->isSigned());
 
-    if (*ConstExprResult < MaxValue && *ConstExprResult >= MinValue)
+    if (*ConstExprResult <= MaxValue && *ConstExprResult >= MinValue)
       return;
   }
 

--- a/clang-tools-extra/clang-tidy/esri/ImplicitCastToSizetCheck.cpp
+++ b/clang-tools-extra/clang-tidy/esri/ImplicitCastToSizetCheck.cpp
@@ -1,0 +1,89 @@
+//===--- ImplicitCastToSizetCheck.cpp - clang-tidy ------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ImplicitCastToSizetCheck.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace esri {
+
+void ImplicitCastToSizetCheck::registerMatchers(MatchFinder *Finder) {
+
+  auto ConditionalWithLiterals = conditionalOperator(
+    hasTrueExpression(integerLiteral()),
+    hasFalseExpression(integerLiteral())
+  );
+
+  Finder->addMatcher(
+    implicitCastExpr(                     // Match implicit casts where...
+      isExpansionInMainFile(),            // ...the cast is in the file being examined
+      hasCastKind(CK_IntegralCast),       // ...is an integral cast (as opposed to ValueCategory cast)
+      hasType(qualType(hasDeclaration(    // ...the type being casted to
+        namedDecl(hasName("size_t"))      // ...is size_t
+      ))),                                // ...and
+      hasSourceExpression(expr(           // ...the source expression
+
+        unless(integerLiteral()),         // ...that isn't a literal
+        unless(has(initListExpr(          // ...or a type initializer (`int32_t{}`)
+          has(integerLiteral()))          // ...that contains a literal
+       )),
+
+        unless(ConditionalWithLiterals),  // ...or a ternary operator where both branches are literals
+        unless(parenExpr(                 // ...or parenthesis surrounding a
+          has(ConditionalWithLiterals)    // ...ternary operator where both branches are literals
+        ))
+      ).bind("se"))
+    ).bind("implicit_cast"),
+    this);
+}
+
+void ImplicitCastToSizetCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *MatchedExpr = Result.Nodes.getNodeAs<ImplicitCastExpr>("implicit_cast");
+  if (MatchedExpr->isPartOfExplicitCast())
+    return;
+
+  const auto *SourceExpr = Result.Nodes.getNodeAs<Expr>("se");
+  if (Result.Context->getTypeSize(SourceExpr->getType()) <= 32)
+    return;
+
+  // See if the source expression can be constant evaluated (such as literals)
+  if (const auto ConstExprResult =
+       SourceExpr->getIntegerConstantExpr(*Result.Context))
+  {
+    const auto ExprResultWidth = ConstExprResult->getBitWidth();
+
+    // If the expression was a 32-bit integer, just make sure the result is
+    // not a negative value
+    if (ExprResultWidth == 32 && !ConstExprResult->isNegative())
+      return;
+    else {
+      // Make sure the constant value was within the valid range for a 32-bit
+      // unsigned integer (size_t on windows_x86)
+      auto MaxValue = llvm::APSInt::getMaxValue(32, true);
+      MaxValue = MaxValue.extOrTrunc(ExprResultWidth);
+      MaxValue.setIsSigned(ConstExprResult->isSigned());
+
+      auto MinValue = llvm::APSInt::getMinValue(32, true);
+      MinValue = MinValue.extOrTrunc(ExprResultWidth);
+      MinValue.setIsSigned(ConstExprResult->isSigned());
+
+      if (*ConstExprResult < MaxValue && *ConstExprResult >= MinValue)
+        return;
+    }
+  }
+
+  diag(MatchedExpr->getBeginLoc(), "implicit cast to size_t may be a narrowing cast")
+      << SourceExpr->getSourceRange();
+}
+
+} // namespace esri
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/esri/ImplicitCastToSizetCheck.h
+++ b/clang-tools-extra/clang-tidy/esri/ImplicitCastToSizetCheck.h
@@ -1,0 +1,36 @@
+//===--- ImplicitCastToSizetCheck.h - clang-tidy ----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_ESRI_IMPLICITCASTTOSIZETCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_ESRI_IMPLICITCASTTOSIZETCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace esri {
+
+/// MSVC defines size_t as a 32-bit unsigned integer in x86 architectures but
+/// not in x64, which means problems converting other integer types to size_t
+/// often go unnoticed during the PR and vTest process.
+///
+/// This check is designed to highlight those problems before they make it into
+/// the codebase and break that configuration of the daily build.
+class ImplicitCastToSizetCheck : public ClangTidyCheck {
+public:
+  ImplicitCastToSizetCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace esri
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_ESRI_IMPLICITCASTTOSIZETCHECK_H

--- a/clang-tools-extra/test/clang-tidy/checkers/esri/esri-implicit-cast-to-sizet.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/esri/esri-implicit-cast-to-sizet.cpp
@@ -1,0 +1,124 @@
+// RUN: %check_clang_tidy %s esri-implicit-cast-to-sizet %t
+
+#include <stddef.h>
+#include <stdint.h>
+
+// Verified cases where a warning is raised
+
+// Several PRs had this specific problem:
+//   * #29277
+//   * #29456
+//   * #29516
+void warning_on_uint64()
+{
+  uint64_t input{1};
+  size_t var = input;
+  // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: implicit cast to size_t may be a narrowing cast
+}
+
+// PR #29503
+void warning_on_longlong()
+{
+  long long input{1};
+  size_t var = input;
+  // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: implicit cast to size_t may be a narrowing cast
+}
+
+/*
+// TODO
+// PR #29516 this different but related warning:
+// warning C4293: '>>': shift count negative or too big, undefined behavior
+void DIFFERENT_WARNING()
+{
+  size_t input{1};
+  uint64_t var = (input >> 32);
+  // TODO-CHECK-MESSAGES: :[[@LINE-1]]:16: warning: implicit cast to size_t may be a narrowing cast
+}
+*/
+
+// NO PR, just additional tests
+void warning_on_adding_variants()
+{
+  // NEEDED?
+  uint64_t base = 1;
+  uint64_t offset = 2;
+  size_t var = base + offset;
+  // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: implicit cast to size_t may be a narrowing cast
+}
+
+void d(size_t);
+
+void warning_when_implicit_passing_value_as_func_argument()
+{
+  uint64_t v{3};
+  d(v); // Follows the same rules as a function argument as init expr
+  // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: implicit cast to size_t may be a narrowing cast
+}
+
+// Verified cases where no warning is raised
+
+void no_warning_for_literals()
+{
+  size_t i = int{1};
+}
+
+void no_warning_for_int32()
+{
+  int32_t signed_int{1};
+  size_t val = signed_int;
+}
+
+void no_warning_for_literals_if_no_truncation()
+{
+  size_t offset_signed = int64_t{1};
+  size_t offset_unsigned = uint64_t{1000};
+  size_t offset_longlong = (long long)10000;
+}
+
+// Other things that could trigger a false positive
+
+void no_warning_when_comparing_to_int32_literal()
+{
+  size_t v{100};
+  bool b = (v == 0);
+}
+
+// When invoking a static member function that returns a value that's then
+// casted to size_t, there's an implicit nested cast for some reason:
+//
+// >> `-CXXStaticCastExpr <col:14, col:42> 'size_t':'unsigned long' static_cast<size_t> <NoOp>
+// >>   `-ImplicitCastExpr <col:34, col:41> 'size_t':'unsigned long' <IntegralCast> part_of_explicit_cast
+//       `-CallExpr <col:34, col:41> 'int'
+//         `-ImplicitCastExpr <col:34, col:37> 'int (*)()' <FunctionToPointerDecay>
+//           `-DeclRefExpr <col:34, col:37> 'int ()' lvalue CXXMethod 0xdcca750 'too' 'int ()'
+//             `-NestedNameSpecifier TypeSpec 'D'
+//
+// The check needs to check the isPartOfExplicitCast() bit
+
+class D
+{
+public:
+  static int too();
+};
+
+void no_warning_when_static_method_invoked_in_explicit_cast()
+{
+  auto val = static_cast<size_t>(D::too());
+}
+
+// Converting a branch from an ternary expression from an integer literal to a
+// size_t should follow the same logic as a regular literal if both branches are
+// literals
+void no_warning_when_casting_literals_from_ternary_expr()
+{
+  size_t i{0};
+  i += false ? 0 : 1;
+  i += (true ? 0 : 1);
+}
+
+// Should follow the same literal rules even if when passing as an argument
+// instead of initializing a variable
+void no_warning_when_passing_casted_argument_with_literal()
+{
+  d(uint64_t{3});
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/esri/esri-implicit-cast-to-sizet.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/esri/esri-implicit-cast-to-sizet.cpp
@@ -55,6 +55,14 @@ void warning_when_implicit_passing_value_as_func_argument()
   // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: implicit cast to size_t may be a narrowing cast
 }
 
+void warning_from_subtraction_of_int64()
+{
+  int64_t input1{2};
+  int64_t input2{1};
+  size_t val = input1 - input2;
+  // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: implicit cast to size_t may be a narrowing cast
+}
+
 // Verified cases where no warning is raised
 
 void no_warning_for_literals()
@@ -73,6 +81,20 @@ void no_warning_for_literals_if_no_truncation()
   size_t offset_signed = int64_t{1};
   size_t offset_unsigned = uint64_t{1000};
   size_t offset_longlong = (long long)10000;
+}
+
+void no_warning_from_subtraction_of_int32()
+{
+  int32_t input1{2};
+  int32_t input2{1};
+  size_t val = input1 - input2;
+}
+
+void no_warning_from_subtraction_of_pointers()
+{
+  const char* text_begin = "Hello";
+  const char* text_end = "World";
+  size_t num_remaining = text_end - text_begin;
 }
 
 // Other things that could trigger a false positive


### PR DESCRIPTION
Try to catch Windows x86-specific narrowing conversion warnings in the clang infrastructure so it's checked for every PR.  These problems are often a build break for the `windows_x86_*` platforms, which very few people test before merging their PR.

This check is currently a little overzealous and pointing out 115 violations in our code base.  We may want to revise the checker if we find a common pattern, or we may just want to be a bit over-prescriptive in making narrowing conversions explicit.