### PR TITLE
doc: Install stripped versions of binaries with cmake files

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ cmake -S llvm-project/llvm -B /llvm/${target}/build -G "Ninja" \
   -DLLVM_ENABLE_RUNTIMES="compiler-rt;libcxx;libcxxabi;libunwind" \
   -DLLVM_EXTERNAL_IWYU_SOURCE_DIR="/llvm/include-what-you-use" \
   -DLLVM_EXTERNAL_PROJECTS="iwyu" \
-  -DLLVM_INSTALL_TOOLCHAIN_ONLY="ON" \
   -DLLVM_RUNTIME_TARGETS="${target}" \
   -DLLVM_USE_LINKER="lld" \
   \
@@ -103,7 +102,7 @@ cmake -S llvm-project/llvm -B /llvm/${target}/build -G "Ninja" \
 cmake --build /llvm/${target}/build -- check-clang-tools
 
 # install
-cmake --build /llvm/${target}/build -- install
+cmake --build /llvm/${target}/build -- install/strip
 ```
 
 Once you're done with the build for x64, exit the container and perform the above step again but this time, using the
@@ -181,7 +180,7 @@ cmake -S /Users/Shared/llvm/llvm-project/llvm -B /Users/Shared/llvm/build -G "Ni
 cmake --build /Users/Shared/llvm/build -- check-clang-tools
 
 # install
-cmake --build /Users/Shared/llvm/build -- install-clang-format install-clang-resource-headers install-clang-tidy tools/iwyu/install
+cmake --build /Users/Shared/llvm/build -- install-clang-format-stripped install-clang-resource-headers-stripped install-clang-tidy-stripped install-cmake-exports-stripped tools/iwyu/install/strip
 
 # zip
 cd /Users/Shared/llvm && zip -r llvm-19.1.2.zip 19.1.2
@@ -212,7 +211,7 @@ cmake -S C:/llvm/llvm-project/llvm -B C:/llvm/build -G "Ninja" ^
 cmake --build C:/llvm/build -- check-clang-tools
 
 :: install
-cmake --build C:/llvm/build -- install-clang-format install-clang-resource-headers install-clang-tidy tools/iwyu/install
+cmake --build C:/llvm/build -- install-clang-format-stripped install-clang-resource-headers-stripped install-clang-tidy-stripped install-cmake-exports-stripped tools/iwyu/install
 
 :: zip
 powershell Compress-Archive C:/llvm/19.1.2 C:/llvm/llvm-19.1.2.zip


### PR DESCRIPTION
Cmake files are going to be used to hook into tooling changes. This requires doing a full install on Linux and explicitly enabling it on the other platforms. Also move to using stripped binaries to reduce the size of our toolchain.