### PR TITLE
clang-tidy: don't try to evaluate dependent types

### DIFF
--- a/clang-tools-extra/clang-tidy/esri/ImplicitCastToSizetCheck.cpp
+++ b/clang-tools-extra/clang-tidy/esri/ImplicitCastToSizetCheck.cpp
@@ -101,7 +101,11 @@ void ImplicitCastToSizetCheck::check(const MatchFinder::MatchResult &Result)
   const auto *SourceExpr = Result.Nodes.getNodeAs<Expr>("se");
   assert(SourceExpr && "Needs to have a source Expr");
 
-  if (Result.Context->getTypeSize(SourceExpr->getType()) <= 32)
+  const auto Type = SourceExpr->getType();
+  if (Type->isDependentType())
+    return;
+
+  if (Result.Context->getTypeSize(Type) <= 32)
     return;
 
   // See if the source expression can be constant evaluated (such as literals)

--- a/clang-tools-extra/test/clang-tidy/checkers/esri/esri-implicit-cast-to-sizet.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/esri/esri-implicit-cast-to-sizet.cpp
@@ -63,6 +63,37 @@ void warning_from_subtraction_of_int64()
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: implicit cast to size_t may be a narrowing cast
 }
 
+/*
+// Unfortunately this case can't be detected because the template instantiation
+// uses the canonical type (aka, 'unsigned long'), so we can't distinguish
+// between foo<size_t>() from foo<uint64_t>()
+// https://stackoverflow.com/questions/79295243/matching-sugared-qualtype-of-a-template-parameter-in-a-vardecl
+template <typename T>
+void foo()
+{
+  uint64_t v{3};
+  T var = v;
+}
+
+void warning_when_sizet_is_dependent_type()
+{
+  foo<size_t>();
+}
+*/
+
+template <typename T>
+void bar()
+{
+  T v{55};
+  size_t var = v;
+  // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: implicit cast to size_t may be a narrowing cast
+}
+
+void warning_when_sizet_assigned_from_dependent_type()
+{
+  bar<int64_t>();
+}
+
 // Verified cases where no warning is raised
 
 void no_warning_for_literals()
@@ -143,4 +174,16 @@ void no_warning_when_casting_literals_from_ternary_expr()
 void no_warning_when_passing_casted_argument_with_literal()
 {
   d(uint64_t{3});
+}
+
+template <typename T>
+void baz()
+{
+  T v{55};
+  size_t var = v;
+}
+
+void no_warning_when_sizet_assigned_from_smaller_dependent_type()
+{
+  baz<int32_t>();
 }


### PR DESCRIPTION
This fixes the issue seen recently with the check segfaulting when run on template code.  Skip evaluation of "dependent types" in a template declaration.  We will still match uses in the template instantiations in cases where a dependent type is assigned to a `size_t`.  Unfortunately we can't correctly match cases where `size_t` is the template parameter, at least not yet.